### PR TITLE
calculate type names live instead of dictionary lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,37 +2,10 @@
 
 var fn = function (something) {
   if (something === void 0 || something === null) return String(something)
-
-  var classToType = {
-    '[object Arguments]': 'arguments',
-    '[object Array]': 'array',
-    '[object ArrayBuffer]': 'arraybuffer',
-    '[object Boolean]': 'boolean',
-    '[object Date]': 'date',
-    '[object Error]': 'error',
-    '[object Float32Array]': 'float32array',
-    '[object Float64Array]': 'float64array',
-    '[object Function]': 'function',
-    '[object GeneratorFunction]': 'generatorfunction',
-    '[object Int16Array]': 'int16array',
-    '[object Int32Array]': 'int32array',
-    '[object Int8Array]': 'int8array',
-    '[object Map]': 'map',
-    '[object Number]': 'number',
-    '[object Object]': 'object',
-    '[object RegExp]': 'regexp',
-    '[object Set]': 'set',
-    '[object String]': 'string',
-    '[object Symbol]': 'symbol',
-    '[object Uint16Array]': 'uint16array',
-    '[object Uint32Array]': 'uint32array',
-    '[object Uint8Array]': 'uint8array',
-    '[object Uint8ClampedArray]': 'uint8clampedarray',
-    '[object WeakMap]': 'weakmap',
-    '[object WeakSet]': 'weakset'
-  }
-
-  return classToType[Object.prototype.toString.call(something)]
+  var className = Object.prototype.toString.call(something
+    ).replace(/^\[Object\s/i, '').replace(/\]$/, '').toLowerCase();
+  if (module.exports.types.indexOf(className) >= 0) { return className; }
+  return '?unsupported?:' + className;
 }
 
 module.exports = fn


### PR DESCRIPTION
Since we have the names in exports.types already, that dict violates DRY.
